### PR TITLE
Add C/C++ extension and c_cpp_properties.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
     "yzhang.markdown-all-in-one",
     "espressif.esp-idf-extension",
     "webfreak.debug",
-    "actboy168.tasks"
+    "actboy168.tasks",
+    "ms-vscode.cpptools"
   ],
   "forwardPorts": [
     9012,

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,6 +11,7 @@ vscode:
     - yzhang.markdown-all-in-one
     - webfreak.debug
     - actboy168.tasks
+    - ms-vscode.cpptools
 ports:
   - port: 9012
     visibility: public

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,11 @@
+{
+    "configurations": [
+        {
+            "name": "ESP-IDF",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "idf.openOcdConfigs": [
     "interface/ftdi/esp32_devkitj_v1.cfg",
     "target/esp32.cfg"
-  ]
+  ],
+  "C_Cpp.intelliSenseEngineFallback": "Enabled"
 }


### PR DESCRIPTION
I added the C/C++ Extension and the .vscode/c_cpp_properties.json to enable Code Navigation, auto-complete and other language support features.

I'm using the compile_commands.json configuration (which requires that the app is built first):
```
{
  "configurations": [
    {
      "name": "ESP-IDF",
      "cStandard": "c11",
      "cppStandard": "c++17",
      "compileCommands": "${workspaceFolder}/build/compile_commands.json"
    }
  ],
  "version": 4
}
```
I also added "C_Cpp.intelliSenseEngineFallback": "Enabled" in settings.json to enable the Tag Parser as fallback.